### PR TITLE
fix quotation marks

### DIFF
--- a/exploration/docs/terminology.tex
+++ b/exploration/docs/terminology.tex
@@ -118,7 +118,7 @@ on the representative - see Riley for details).
 
 This definition makes maniffest the combination of co- and contravariant data.
 For a representative $\langle l | r \rangle$, $l$ varies covariantly while $r$
-varies contravariantly. We additionally have a "memory" or "residual" object $M$.
+varies contravariantly. We additionally have a ``memory" or ``residual" object $M$.
 This object is not uniquely determined and in fact we shall make good use of that
 fact in our actual use case later. For now, We briefly exhibit the composition rules for these
 morphisms. Suppose $\langle l_1 | r_1 \rangle: (A, A') \hto (B, B')$,
@@ -465,7 +465,7 @@ Now, we have an operation $\varphi: A \oplus A \to A$, that joins control flow e
     \end{tikzpicture}
 \end{equation}
 
-and we will introduce an additional "conditonal branch" operation $br: A \otimes C \to A \oplus A$ (where we say $C$
+and we will introduce an additional ``conditonal branch" operation $br: A \otimes C \to A \oplus A$ (where we say $C$
 is the condition):
 
 \begin{equation}
@@ -995,7 +995,7 @@ p \langle l | r \rangle f = l \bbsemi (id_M \otimes f) \bbsemi r
 \]
 
 or graphically by assigning to a morphism $f \in \Hom(B, B^\prime)$ the morphism
-obtained by plugging $f$ into the "hole" of the optic:
+obtained by plugging $f$ into the ``hole" of the optic:
 
 \begin{equation}
     \begin{tikzpicture}[baseline=(S)]
@@ -1109,7 +1109,7 @@ let's look at the graphical representation:
 \end{equation}
 
 Here the dashed line plays the same role it did in the original diagram of
-the optic: To compose optics, we "slice" along the dashed line and insert
+the optic: To compose optics, we ``slice" along the dashed line and insert
 the next higher order optic in the middle. To illustrate the composition,
 we will first look at two diagrams stacked on top of each other using the
 same structure as in the previous diagram, to make the flow of operations
@@ -1679,7 +1679,7 @@ transform in the Appendix (figure \ref{3-ordernaive}).
 
 The previous approach works, but it is somewhat unsatisfying. Why? For me the two
 primary reasons are that there is no manifest difference between the residuals
-and the "holes" of the optic and that control flow is somewhat non-transparent.
+and the ``holes" of the optic and that control flow is somewhat non-transparent.
 At first order, the residual was encoded as the
 capture of the original closure. However, at second order, while most residuals
 are still closure captures, $\Delta^{\prime\prime}$ is a residual, but does not


### PR DESCRIPTION
In LaTeX, you need to write ` ``x" ` to render proper quotation marks. 